### PR TITLE
Making all sucessfull Mesh::Get paths registerMesh

### DIFF
--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -1591,7 +1591,7 @@ Mesh* Mesh::Get(const char* filename)
 		}
 
 		std::cout << "[OK BIN]  Faces: " << (m->interleaved.size() ? m->interleaved.size() : m->vertices.size()) / 3 << " Time: " << (getTime() - time) * 0.001 << "sec" << std::endl;
-		sMeshesLoaded[filename] = m;
+		m->registerMesh(name);
 		return m;
 	}
 


### PR DESCRIPTION
fixes binary meshes loaded having empty name